### PR TITLE
Toevoeging instructie Docker voor Windows

### DIFF
--- a/guides/docker.md
+++ b/guides/docker.md
@@ -51,6 +51,12 @@ services:
 
 ```
 
+Indien men Docker op Microsoft Windows gebruikt moeten de *nix* paden die gebruikt worden in het bovenstaande script geconverteerd worden. Voer hiertoe het volgende commando uit alvorens docker-compose.
+
+```
+$Env:COMPOSE_CONVERT_WINDOWS_PATHS=1
+```
+
 Voer vanuit deze directory vervolgens het commando *docker-compose up -d*  commando uit:
 
 ```


### PR DESCRIPTION
Digest: sha256:1d257a8ec89b929d03ee44d969c22b20fe47a00b0aecfeb1d02a4dc3a4231c88
Status: Downloaded newer image for dockerhaarlem/zaakregistratiecomponent:1.1
Creating zaaksysteem_alfresco_1 ...
Creating zaaksysteem_zr_1       ... error
Creating zaaksysteem_zr-db_1    ...

ERROR: for zaaksysteem_zr_1  Cannot create container for service zr: b'Mount denied:\nThe source path "\\\\sys\\\\fs\\\\cgroupCreating zaaksysteem_zr-db_1    ... error
Creating zaaksysteem_alfresco_1 ... error
ERROR: for zaaksysteem_zr-db_1  Cannot create container for service zr-db: b'Mount denied:\nThe source path "\\\\sys\\\\fs\\\\cgroup:/sys/fs/cgroup"\nis not a valid Windcgroup:/sys/fs/cgroup"\nis not a valid Windows path'

ERROR: for zaaksysteem_alfresco_1  Cannot create container for service alfresco: b'Mount denied:\nThe source path "\\\\sys\\\\fs\\\\cgroup:/sys/fs/cgroup"\nis not a valifs\\\\cgroup:/sys/fs/cgroup"\nis not a valid Windows path'

ERROR: for zr  Cannot create container for service zr: b'Mount denied:\nThe source path "\\\\sys\\\\fs\\\\cgroup:/sys/fs/cgroup"\nis not a valid Windows path'p"\nis not a valid Windows path'
                                                                                                                              /cgroup"\nis not a valid Windows path'
ERROR: for zr-db  Cannot create container for service zr-db: b'Mount denied:\nThe source path "\\\\sys\\\\fs\\\\cgroup:/sys/fs/cgroup"\nis not a valid Windows path'                                                                                        sys/fs/cgroup"\nis not a valid Windows path
ERROR: for alfresco  Cannot create container for service alfresco: b'Mount denied:\nThe source path "\\\\sys\\\\fs\\\\cgroup:/sys/fs/cgroup"\nis not a valid Windows path'
