### PR TITLE
A more detailed description of the IOTA Verifiable Claims PoC

### DIFF
--- a/projects/digitale_waardepapieren.md
+++ b/projects/digitale_waardepapieren.md
@@ -1,18 +1,18 @@
 ---
-abstract: Digitale Waardepapieren
+abstract: Proof of concept for publishing and verifying digital certificates on the "blockchain"
 ---
 
-# Digitale Waardepapieren
+# IOTA Verifiable Claims Proof of Concept
 
-![Status: Proof of Concept](https://img.shields.io/badge/Status-Proof%20Of%20Concept-lightgrey.svg)
+Status: 👩‍🔬 Proof of Concept
 
-This project is an example of how to use the IOTA tangle with the discipl-code library to publish certificates. These replace the certificates we have to print on expensive forge-proof paper, increasing the speed of and decreasing the cost of our digital service delivery.
+This project is an example of how to use the [IOTA](iota.org) [tangle](https://learn.iota.org/faq/tangle) with [Discipl](https://discipl.org/) library to publish digital [verifiable claims](https://www.w3.org/TR/verifiable-claims-use-cases/). These digital certificates replace the certificates the City of Haarlem has to print on expensive forge-proof paper. Thus increasing the speed and decreasing the cost of our digital service delivery.
 
-## Contributing
+There are many more possible applications for digital verifiable claims in public administrations. This [proof of concept](https://github.com/Haarlem/digitale-waardepapieren/blob/develop/docs/proof-of-concept.md) demonstrates where we can start.
+However, once these verifiable claims are digital many others can also be digitised on the same infrastructure, dramatically lowering the barrier to using verifications.
 
-Please feel free to file Issues and Pull Requests against this project. Thanks for contributing.
+Read more on this project, read the source and try it out for yourself on the [GitHub: Haarlem/digitale-waardepapieren](https://github.com/Haarlem/digitale-waardepapieren)
 
-## Licence
-
-© 2018 [Gemeente Haarlem](https://haarlem.nl)  
-This project is licenced under the [GNU General Public Licence](LICENCE)
+* [Why we've made this this Proof of Concept](https://github.com/Haarlem/digitale-waardepapieren/blob/develop/docs/proof-of-concept.md)
+* [The scenario this Proof of Concept fulfills](https://github.com/Haarlem/digitale-waardepapieren/blob/develop/docs/scenario.md)
+* [The technologies we use, why we've used them and how they work](https://github.com/Haarlem/digitale-waardepapieren/blob/develop/docs/technologies.md)


### PR DESCRIPTION
Including an abstract to give a bit more context on the overview page. I've included links to the relevant articles mentioned in the README as I feel they are probably relevant for those interested in this project.

Licence, copyright and contributing information seems to be an extra nice-to-have so I've removed it, I think it serves better in the `README`.

This is the first out of a series of PR's, to test the waters.